### PR TITLE
Enable qsv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,8 @@
 /epgstation/thumbnail/*.jpg
 /epgstation/data/streamfiles/*.ts
 /epgstation/data/streamfiles/*.m3u8
-/epgstation/config/*.json
 !/epgstation/config/config.sample.json
 !/epgstation/config/operatorLogConfig.json
 !/epgstation/config/serviceLogConfig.json
 /epgstation/data/*.json
 !.gitkeep
-/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+version: '3.7'
+services:
+    mirakurun:
+        build:
+            context: mirakurun
+        # image: chinachu/mirakurun:3.2.0
+        cap_add:
+            - SYS_ADMIN
+            - SYS_NICE
+        ports:
+            - 40772:40772
+            - 9229:9229
+        volumes:
+            - ./mirakurun/conf:/app-config
+            - ./mirakurun/data:/app-data
+        environment:
+            TZ: "Asia/Tokyo"
+            # LOG_LEVEL: "3"
+            # DEBUG: "true"
+        devices:
+            - /dev/bus:/dev/bus
+            - /dev/px4video0:/dev/px4video0
+            - /dev/px4video1:/dev/px4video1
+            - /dev/px4video2:/dev/px4video2
+            - /dev/px4video3:/dev/px4video3
+            # - /dev/dvb:/dev/dvb
+        restart: always
+        logging:
+            driver: json-file
+            options:
+                max-file: "1"
+                max-size: 10m
+
+    mysql:
+        image: mariadb:10.4
+        volumes:
+            - mysql-db:/var/lib/mysql
+        environment:
+            MYSQL_USER: epgstation
+            MYSQL_PASSWORD: epgstation
+            MYSQL_ROOT_PASSWORD: epgstation
+            MYSQL_DATABASE: epgstation
+            TZ: "Asia/Tokyo"
+        command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --performance-schema=false --expire_logs_days=1
+        restart: always
+        logging:
+            options:
+                max-size: "10m"
+                max-file: "3"
+
+    epgstation:
+        build:
+            context: epgstation
+            args:
+                - CPUCORE=2
+        cap_add:
+            - ALL
+        volumes:
+            - /etc/localtime:/etc/localtime:ro
+            - ./epgstation/config:/app/config
+            - ./epgstation/data:/app/data
+            - ./epgstation/thumbnail:/app/thumbnail
+            - ./epgstation/logs:/app/logs
+            - ./recorded:/app/recorded
+        devices:
+            - /dev/dri:/dev/dri
+        environment:
+            TZ: "Asia/Tokyo"
+        depends_on:
+            - mirakurun
+            - mysql
+        ports:
+            - "8888:8888"
+            - "8889:8889"
+        # user: "0:0"
+        restart: always
+volumes:
+    mysql-db:
+        driver: local
+

--- a/epgstation/Dockerfile
+++ b/epgstation/Dockerfile
@@ -6,6 +6,7 @@ ENV FFMPEG_VERSION=4.1
 
 RUN apt-get update && \
     apt-get -y install $DEV && \
+    apt-get -y install i965-va-driver vainfo && \
     apt-get -y install yasm libx264-dev libmp3lame-dev libopus-dev libvpx-dev && \
     apt-get -y install libx265-dev libnuma-dev && \
     apt-get -y install libasound2 libass9 libvdpau1 libva-x11-2 libva-drm2 libxcb-shm0 libxcb-xfixes0 libxcb-shape0 libvorbisenc2 libtheora0 && \
@@ -32,6 +33,7 @@ RUN apt-get update && \
       --enable-libx264 \
       --enable-libx265 \
       --enable-nonfree \
+      --enable-vaapi \
       --disable-debug \
       --disable-doc \
     && \
@@ -46,4 +48,3 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/ffmpeg_sources
-

--- a/epgstation/config/config.json
+++ b/epgstation/config/config.json
@@ -1,0 +1,139 @@
+{
+    "serverPort": 8888,
+    "mirakurunPath": "http://mirakurun:40772/",
+    "mysql": {
+        "host": "mysql",
+        "user": "epgstation",
+        "database": "epgstation",
+        "password": "epgstation",
+        "connectTimeout": 1000,
+        "connectionLimit": 10
+    },
+    "excludeServices": [],
+    "maxEncode": 2,
+    "encode": [
+        {
+            "name": "H264",
+            "cmd": "%NODE% %ROOT%/config/enc.js",
+            "suffix": ".mp4",
+            "default": true
+        }
+    ],
+    "recordedViewer": {
+        "ios": "infuse://x-callback-url/play?url=http://ADDRESS",
+        "android": "intent://ADDRESS#Intent;package=org.videolan.vlc;type=video;scheme=https;end"
+    },
+    "recordedDownloader": {
+        "ios": "vlc-x-callback://x-callback-url/download?url=http://ADDRESS&filename=FILENAME"
+    },
+    "maxStreaming": 4,
+    "mpegTsViewer": {
+        "ios": "vlc-x-callback://x-callback-url/stream?url=http://ADDRESS",
+        "android": "intent://ADDRESS#Intent;package=org.videolan.vlc;type=video;scheme=https;end"
+    },
+    "mpegTsStreaming": [
+        {
+            "name": "720p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -vaapi_device /dev/dri/renderD128 -i pipe:0 -vf format=nv12|vaapi,hwupload,deinterlace_vaapi,scale_vaapi=w=1280:h=720 -c:a aac -ar 48000 -ab 192k -ac 2 -c:v h264_vaapi -level 40 -aspect 16:9 -qp 23 -f mpegts pipe:1"
+        },
+        {
+            "name": "480p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -vaapi_device /dev/dri/renderD128 -i pipe:0 -vf format=nv12|vaapi,hwupload,deinterlace_vaapi,scale_vaapi=w=720:h=480 -c:a aac -ar 48000 -ab 128k -ac 2 -c:v h264_vaapi -level 40 -aspect 16:9 -vb 1500k -f mpegts pipe:1"
+        },
+        {
+            "name": "無変換"
+        }
+    ],
+    "recordedHLS": [
+        {
+            "name": "720p",
+            "cmd": "%FFMPEG% -dual_mono_mode main -vaapi_device /dev/dri/renderD128 -i %INPUT% -vf format=nv12|vaapi,hwupload,deinterlace_vaapi,scale_vaapi=w=1280:h=720 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 192k -ac 2 -c:v h264_vaapi -level 40 -aspect 16:9 -qp 23 -flags +loop-global_header %OUTPUT%"
+        },
+        {
+            "name": "480p",
+            "cmd": "%FFMPEG% -dual_mono_mode main -vaapi_device /dev/dri/renderD128 -i %INPUT% -vf format=nv12|vaapi,hwupload,deinterlace_vaapi,scale_vaapi=w=720:h=480 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -threads auto -c:a aac -ar 48000 -ab 128k -ac 2 -c:v h264_vaapi -level 40 -aspect 16:9 -vb 1500k -flags +loop-global_header %OUTPUT%"
+        },
+        {
+            "name": "480p(h265)",
+            "cmd": "%FFMPEG% -dual_mono_mode main -i %INPUT% -sn -map 0 -ignore_unknown -max_muxing_queue_size 1024 -f hls -hls_time 3 -hls_list_size 0 -hls_allow_cache 1 -hls_segment_type fmp4 -hls_fmp4_init_filename stream%streamNum%-init.mp4 -hls_segment_filename stream%streamNum%-%09d.m4s -c:a aac -ar 48000 -b:a 128k -ac 2 -c:v libx265 -vf yadif,scale=-2:480 -b:v 350k -preset veryfast -tag:v hvc1 %OUTPUT%"
+        }
+    ],
+    "liveHLS": [
+        {
+            "name": "720p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -vaapi_device /dev/dri/renderD128 -i pipe:0 -sn -threads 0 -map 0 -ignore_unknown -max_muxing_queue_size 1024 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -c:a aac -ar 48000 -b:a 192k -ac 2 -c:v h264_vaapi -vf format=nv12|vaapi,hwupload,deinterlace_vaapi,scale_vaapi=w=1280:h=720 -qp 21 -preset veryfast -flags +loop-global_header %OUTPUT%"
+        },
+        {
+            "name": "480p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -vaapi_device /dev/dri/renderD128 -i pipe:0 -sn -threads 0 -map 0 -ignore_unknown -max_muxing_queue_size 1024 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -c:a aac -ar 48000 -b:a 192k -ac 2 -c:v h264_vaapi -vf format=nv12|vaapi,hwupload,deinterlace_vaapi,scale_vaapi=w=720:h=480 -qp 21 -preset veryfast -flags +loop-global_header %OUTPUT%"
+        },
+        {
+            "name": "180p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -sn -threads 0 -map 0 -ignore_unknown -max_muxing_queue_size 1024 -f hls -hls_time 3 -hls_list_size 17 -hls_allow_cache 1 -hls_segment_filename %streamFileDir%/stream%streamNum%-%09d.ts -c:a aac -ar 48000 -b:a 48k -ac 2 -c:v libx264 -vf yadif,scale=-2:180 -b:v 100k -preset veryfast -maxrate 110k -bufsize 1000k -flags +loop-global_header %OUTPUT%"
+        }
+    ],
+    "liveWebM": [
+        {
+            "name": "720p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -sn -threads 3 -c:a libvorbis -ar 48000 -b:a 192k -ac 2 -c:v libvpx-vp9 -vf yadif,scale=-2:720 -b:v 3000k -deadline realtime -speed 4 -cpu-used -8 -y -f webm pipe:1"
+        },
+        {
+            "name": "480p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -sn -threads 2 -c:a libvorbis -ar 48000 -b:a 128k -ac 2 -c:v libvpx-vp9 -vf yadif,scale=-2:480 -b:v 1500k -deadline realtime -speed 4 -cpu-used -8 -y -f webm pipe:1"
+        }
+    ],
+    "liveMP4": [
+        {
+            "name": "720p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -sn -threads 0 -c:a aac -ar 48000 -b:a 192k -ac 2 -c:v libx264 -vf yadif,scale=-2:720 -b:v 3000k -profile:v baseline -preset veryfast -tune fastdecode,zerolatency -movflags frag_keyframe+empty_moov+faststart+default_base_moof -y -f mp4 pipe:1"
+        },
+        {
+            "name": "480p",
+            "cmd": "%FFMPEG% -re -dual_mono_mode main -i pipe:0 -sn -threads 0 -c:a aac -ar 48000 -b:a 128k -ac 2 -c:v libx264 -vf yadif,scale=-2:480 -b:v 1500k -profile:v baseline -preset veryfast -tune fastdecode,zerolatency -movflags frag_keyframe+empty_moov+faststart+default_base_moof -y -f mp4 pipe:1"
+        }
+    ],
+    "recordedStreaming": {
+        "webm": [
+            {
+                "name": "720p",
+                "cmd": "%FFMPEG% -dual_mono_mode main %RE% -i pipe:0 -sn -threads 3 -c:a libvorbis -ar 48000 -ac 2 -c:v libvpx-vp9 -vf yadif,scale=-2:720 %VB% %VBUFFER% %AB% %ABUFFER% -deadline realtime -speed 4 -cpu-used -8 -y -f webm pipe:1",
+                "vb": "3000k",
+                "ab": "192k"
+            },
+            {
+                "name": "360p",
+                "cmd": "%FFMPEG% -dual_mono_mode main %RE% -i pipe:0 -sn -threads 2 -c:a libvorbis -ar 48000 -ac 2 -c:v libvpx-vp9 -vf yadif,scale=-2:360 %VB% %VBUFFER% %AB% %ABUFFER% -deadline realtime -speed 4 -cpu-used -8 -y -f webm pipe:1",
+                "vb": "1500k",
+                "ab": "128k"
+            }
+        ],
+        "mp4": [
+            {
+                "name": "720p",
+                "cmd": "%FFMPEG% -dual_mono_mode main %RE% -i pipe:0 -sn -threads 0 -c:a aac -ar 48000 -ac 2 -c:v libx264 -vf yadif,scale=-2:720 %VB% %VBUFFER% %AB% %ABUFFER% -profile:v baseline -preset veryfast -tune fastdecode,zerolatency -movflags frag_keyframe+empty_moov+faststart+default_base_moof -y -f mp4 pipe:1",
+                "vb": "3000k",
+                "ab": "192k"
+            },
+            {
+                "name": "360p",
+                "cmd": "%FFMPEG% -dual_mono_mode main %RE% -i pipe:0 -sn -threads 0 -c:a aac -ar 48000 -ac 2 -c:v libx264 -vf yadif,scale=-2:360 %VB% %VBUFFER% %AB% %ABUFFER% -profile:v baseline -preset veryfast -tune fastdecode,zerolatency -movflags frag_keyframe+empty_moov+faststart+default_base_moof -y -f mp4 pipe:1",
+                "vb": "1500k",
+                "ab": "128k"
+            }
+        ],
+        "mpegTs": [
+            {
+                "name": "720p (H.264)",
+                "cmd": "%FFMPEG% -dual_mono_mode main %RE% -i pipe:0 -sn -threads 0 -c:a aac -ar 48000 -ac 2 -c:v libx264 -vf yadif,scale=-2:720 %VB% %VBUFFER% %AB% %ABUFFER% -profile:v baseline -preset veryfast -tune fastdecode,zerolatency -y -f mpegts pipe:1",
+                "vb": "3000k",
+                "ab": "192k"
+            },
+            {
+                "name": "360p (H.264)",
+                "cmd": "%FFMPEG% -dual_mono_mode main %RE% -i pipe:0 -sn -threads 0 -c:a aac -ar 48000 -ac 2 -c:v libx264 -vf yadif,scale=-2:360 %VB% %VBUFFER% %AB% %ABUFFER% -profile:v baseline -preset veryfast -tune fastdecode,zerolatency -y -f mpegts pipe:1",
+                "vb": "1500k",
+                "ab": "128k"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- Epgstaion の Dockerfile で QSV(vaapi) が動くように 3cc99fa
    - `i965-va-driver` なのは私が Sandy おじさんだからです
    - `Broadwell` 以降を使っている場合は `intel-media-driver` 使ったほうがいいと思います
- config を管理できるように .gitignore を更新 4e201eb
- docker-compose.yml を追加 2fbc6fc
- config.json で ストリーミング周りで qsv エンコード対応  caa5d95
    - M2TS / HLS で使っています
    - 動作確認は `intel_gpu_top` をインストールして確認するといいかもです
    - まぁ私は劇的にCPU使用率減ったので確認できましたが・・・